### PR TITLE
Small linux fixes

### DIFF
--- a/src/Audio/AudioTags.cpp
+++ b/src/Audio/AudioTags.cpp
@@ -603,7 +603,7 @@ wxString parseID3v2Tag(MemChunk& mc, size_t start)
 	if (artist.length())
 		ret += wxString::Format("Artist%s: %s\n", artists ? "s" : "", artist);
 	if (copyright.length())
-		ret += wxString::Format("Copyright \x00A9 %s\n", copyright);
+		ret += wxString::Format(wxString::FromUTF8("Copyright \xC2\xA9 %s\n"), copyright);
 	if (year.length())
 		ret += wxString::Format("Year: %s\n", year);
 	if (genre.length())

--- a/src/MainEditor/UI/ArchivePanel.cpp
+++ b/src/MainEditor/UI/ArchivePanel.cpp
@@ -691,7 +691,12 @@ void ArchivePanel::addMenus() const
 		SAction::fromId("arch_texeditor")->addToMenu(menu_archive);
 		SAction::fromId("arch_mapeditor")->addToMenu(menu_archive);
 		auto menu_clean = createMaintenanceMenu();
-		menu_archive->AppendSubMenu(menu_clean, "&Maintenance")->SetBitmap(icons::getIcon(icons::Type::Any, "wrench"));
+
+		wxMenuItem *maintenanceItem = new wxMenuItem(menu_archive, wxID_ANY, "&Maintenance");
+		maintenanceItem->SetSubMenu(menu_clean);
+		maintenanceItem->SetBitmap(icons::getIcon(icons::Type::Any, "wrench"));
+		menu_archive->Append(maintenanceItem);
+
 		auto menu_scripts = new wxMenu();
 #ifndef NO_LUA
 		scriptmanager::populateEditorScriptMenu(menu_scripts, scriptmanager::ScriptType::Archive, "arch_script");
@@ -3711,7 +3716,10 @@ void ArchivePanel::onEntryListRightClick(wxDataViewEvent& e)
 		SAction::fromId("arch_entry_bookmark")->addToMenu(&context, true);
 
 	// Add 'Open In' menu
-	context.AppendSubMenu(createEntryOpenMenu(category), "Open")->SetBitmap(icons::getIcon(icons::General, "open"));
+	wxMenuItem *openItem = new wxMenuItem(&context, wxID_ANY, "Open");
+	openItem->SetSubMenu(createEntryOpenMenu(category));
+	openItem->SetBitmap(icons::getIcon(icons::General, "open"));
+	context.Append(openItem);
 
 	// Add custom menu items
 	wxMenu* custom;


### PR DESCRIPTION
When reading the copyright ID3v2 of a music file, in this piece of code:
    wxString::Format("Copyright \x00A9 %s\n", copyright);
The 1st argument is converted to a wxString using the current locale encoding.

If the encoding is UTF-8 (typically Linux), this string is invalidly encoded
and ends up causing a crash inside wxString::format.

Explicitly specify the encoding to avoid this.